### PR TITLE
Remove armv7 support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ github.token }}
           PULL_REQUEST: ${{ github.event.pull_request.number }}
-        run: brew pr-pull --debug --tap=$GITHUB_REPOSITORY $PULL_REQUEST
+        run: brew pr-pull --debug --tap="${GITHUB_REPOSITORY}" "${PULL_REQUEST}"
 
       - name: Push commits
         uses: Homebrew/actions/git-try-push@master
@@ -30,4 +30,4 @@ jobs:
         if: github.event.pull_request.head.repo.fork == false
         env:
           BRANCH: ${{ github.event.pull_request.head.ref }}
-        run: git push --delete origin $BRANCH
+        run: git push --delete origin "${BRANCH}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Cache Homebrew Bundler RubyGems
         id: cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}

--- a/scripts/generate-formulas/main.go
+++ b/scripts/generate-formulas/main.go
@@ -23,7 +23,6 @@ type Shas struct {
 	DarwinArm64 string
 	LinuxAmd64  string
 	LinuxArm64  string
-	LinuxArmv7  string
 }
 
 func (s *Shas) Validate() {
@@ -166,8 +165,6 @@ func parseChecksums(checksums []byte, tag string) map[string]*Shas {
 			shasMapping[name].LinuxAmd64 = sha
 		} else if os == "linux" && arch == "arm64" {
 			shasMapping[name].LinuxArm64 = sha
-		} else if os == "linux" && arch == "armv7" {
-			shasMapping[name].LinuxArmv7 = sha
 		}
 	}
 	return shasMapping

--- a/scripts/generate-formulas/main_test.go
+++ b/scripts/generate-formulas/main_test.go
@@ -26,7 +26,6 @@ func TestValidateNoPanic(t *testing.T) {
 		DarwinArm64: "0fea948d10091a8442c97d872eff7c81ae73d522415118d6ce81bcb2c0f35fa5",
 		LinuxAmd64:  "e08b5c83558efc8e2e3a273f6166c93e3f7d0f8daa98557f2eb05c691480cf66",
 		LinuxArm64:  "7360b4c12ffe789e8b12030b164c45299d4514f063d4c7b87498d2aa89c5b0af",
-		LinuxArmv7:  "eaa32afde7306a4de06bd7a770a677edff733a7c9dbd21fa935c0f3f07850250",
 	}
 
 	s.Validate()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove `armv7` support from `main.go`, `main_test.go`, and update workflow files for consistency and newer action versions.
> 
>   - **Architecture Support**:
>     - Remove `LinuxArmv7` from `Shas` struct in `main.go` and related logic in `parseChecksums()`.
>     - Update `TestValidateNoPanic` in `main_test.go` to remove `LinuxArmv7` test case.
>   - **Workflow Updates**:
>     - Update `publish.yml` to use double quotes for variables in `brew pr-pull` and `git push` commands.
>     - Update `tests.yml` to use `actions/cache@v4` instead of `v1`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=pyroscope-io%2Fhomebrew-brew&utm_source=github&utm_medium=referral)<sup> for fc6435a67daa4a27d3a909f9b08d69f7110c7b44. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->