### PR TITLE
remove armv7 section from formulas templates

### DIFF
--- a/Formula/profilecli.rb.tpl
+++ b/Formula/profilecli.rb.tpl
@@ -42,14 +42,7 @@ class Profilecli < Formula
           bin.install "profilecli"
         end
       end
-      unless Hardware::CPU.is_64_bit?
-        url "https://github.com/grafana/pyroscope/releases/download/{{.Tag}}/profilecli_{{.Version}}_linux_armv7.tar.gz"
-        sha256 "{{.LinuxArmv7}}"
-
-        def install
-          bin.install "profilecli"
-        end
-      end
+      # Removed armv7 section as it's deprecated
     end
   end
 

--- a/Formula/pyroscope.rb.tpl
+++ b/Formula/pyroscope.rb.tpl
@@ -50,14 +50,7 @@ class Pyroscope < Formula
           bin.install "pyroscope"
         end
       end
-      unless Hardware::CPU.is_64_bit?
-        url "https://github.com/grafana/pyroscope/releases/download/{{.Tag}}/pyroscope_{{.Version}}_linux_armv7.tar.gz"
-        sha256 "{{.LinuxArmv7}}"
-
-        def install
-          bin.install "pyroscope"
-        end
-      end
+      # Removed armv7 section as it's deprecated
     end
   end
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove deprecated armv7 support from `profilecli.rb.tpl` and `pyroscope.rb.tpl`.
> 
>   - **Removal of armv7 support**:
>     - Removed armv7 section from `profilecli.rb.tpl` and `pyroscope.rb.tpl` as it's deprecated.
>     - Affects Linux installations for non-64-bit ARM CPUs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=pyroscope-io%2Fhomebrew-brew&utm_source=github&utm_medium=referral)<sup> for a6552d9a1faef6a9ce4405296ea3c9429b9eb868. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->