### PR TITLE
Revert "chore: update formulas"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,5 +39,5 @@ jobs:
         if: always() && github.event_name == 'pull_request'
         uses: actions/upload-artifact@main
         with:
-          name: bottles
+          name: bottles-${{ matrix.os }}
           path: '*.bottle.*'

--- a/Formula/profilecli.rb
+++ b/Formula/profilecli.rb
@@ -33,16 +33,13 @@ class Profilecli < Formula
         bin.install "profilecli"
       end
     end
-    if Hardware::CPU.arm?
-      if Hardware::CPU.is_64_bit?
-        url "https://github.com/grafana/pyroscope/releases/download/v1.13.2/profilecli_1.13.2_linux_arm64.tar.gz"
-        sha256 "c91d7b96a07e29849fc0b5f9c08a2b1062c2f1e04b50d189a22d6cb46ba8878e"
+    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+      url "https://github.com/grafana/pyroscope/releases/download/v1.13.2/profilecli_1.13.2_linux_arm64.tar.gz"
+      sha256 "c91d7b96a07e29849fc0b5f9c08a2b1062c2f1e04b50d189a22d6cb46ba8878e"
 
-        def install
-          bin.install "profilecli"
-        end
+      def install
+        bin.install "profilecli"
       end
-      # Removed armv7 section as it's deprecated
     end
   end
 

--- a/Formula/profilecli.rb
+++ b/Formula/profilecli.rb
@@ -2,21 +2,21 @@
 class Profilecli < Formula
   desc "Open source continuous profiling software"
   homepage "https://grafana.com/oss/pyroscope/"
-  version "1.12.2"
+  version "1.13.2"
   license "AGPL-3.0-only"
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/grafana/pyroscope/releases/download/v1.12.2/profilecli_1.12.2_darwin_amd64.tar.gz"
-      sha256 "b3d8f70296cf9f05d35865b4ad5ec00712d0f44be07ce9663ac935edf9e03534"
+      url "https://github.com/grafana/pyroscope/releases/download/v1.13.2/profilecli_1.13.2_darwin_amd64.tar.gz"
+      sha256 "fe228889483e1bef3f513ca6a9b833eb3fc193bad56ec73556ba2725152f1564"
 
       def install
         bin.install "profilecli"
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/grafana/pyroscope/releases/download/v1.12.2/profilecli_1.12.2_darwin_arm64.tar.gz"
-      sha256 "9fb05403d49cf9dcb177590c6779a5cbac28a5de8465abce9610d0cd5ffef6d5"
+      url "https://github.com/grafana/pyroscope/releases/download/v1.13.2/profilecli_1.13.2_darwin_arm64.tar.gz"
+      sha256 "bea3c08f372b4764e87dad294fa1c5823d79e63530dd83b55be42942f748e676"
 
       def install
         bin.install "profilecli"
@@ -26,8 +26,8 @@ class Profilecli < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/grafana/pyroscope/releases/download/v1.12.2/profilecli_1.12.2_linux_amd64.tar.gz"
-      sha256 "b48a932af8d20147a98f0fb4ba243bcba06fd1ccddd050e0f08dd934c0c314da"
+      url "https://github.com/grafana/pyroscope/releases/download/v1.13.2/profilecli_1.13.2_linux_amd64.tar.gz"
+      sha256 "345b0e5c01afeda00a8745b7a3ca19d652b8b1b0858a1aa8ded08a558bed574f"
 
       def install
         bin.install "profilecli"
@@ -35,8 +35,8 @@ class Profilecli < Formula
     end
     if Hardware::CPU.arm?
       if Hardware::CPU.is_64_bit?
-        url "https://github.com/grafana/pyroscope/releases/download/v1.12.2/profilecli_1.12.2_linux_arm64.tar.gz"
-        sha256 "a7c7488bb396e9d5393e1cc17c910e2af0cba53fa16b6b3431dbf2cb2f5a6aab"
+        url "https://github.com/grafana/pyroscope/releases/download/v1.13.2/profilecli_1.13.2_linux_arm64.tar.gz"
+        sha256 "c91d7b96a07e29849fc0b5f9c08a2b1062c2f1e04b50d189a22d6cb46ba8878e"
 
         def install
           bin.install "profilecli"

--- a/Formula/profilecli.rb.tpl
+++ b/Formula/profilecli.rb.tpl
@@ -33,16 +33,13 @@ class Profilecli < Formula
         bin.install "profilecli"
       end
     end
-    if Hardware::CPU.arm?
-      if Hardware::CPU.is_64_bit?
-        url "https://github.com/grafana/pyroscope/releases/download/{{.Tag}}/profilecli_{{.Version}}_linux_arm64.tar.gz"
-        sha256 "{{.LinuxArm64}}"
+    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+      url "https://github.com/grafana/pyroscope/releases/download/{{.Tag}}/profilecli_{{.Version}}_linux_arm64.tar.gz"
+      sha256 "{{.LinuxArm64}}"
 
-        def install
-          bin.install "profilecli"
-        end
+      def install
+        bin.install "profilecli"
       end
-      # Removed armv7 section as it's deprecated
     end
   end
 

--- a/Formula/pyroscope.rb
+++ b/Formula/pyroscope.rb
@@ -41,16 +41,13 @@ class Pyroscope < Formula
         bin.install "pyroscope"
       end
     end
-    if Hardware::CPU.arm?
-      if Hardware::CPU.is_64_bit?
-        url "https://github.com/grafana/pyroscope/releases/download/v1.13.2/pyroscope_1.13.2_linux_arm64.tar.gz"
-        sha256 "4ba5ba5fd5aaab24465e47f3beadab578a784db94b429e6ba96f06441bc90c2d"
+    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+      url "https://github.com/grafana/pyroscope/releases/download/v1.13.2/pyroscope_1.13.2_linux_arm64.tar.gz"
+      sha256 "4ba5ba5fd5aaab24465e47f3beadab578a784db94b429e6ba96f06441bc90c2d"
 
-        def install
-          bin.install "pyroscope"
-        end
+      def install
+        bin.install "pyroscope"
       end
-      # Removed armv7 section as it's deprecated
     end
   end
 

--- a/Formula/pyroscope.rb
+++ b/Formula/pyroscope.rb
@@ -2,7 +2,7 @@
 class Pyroscope < Formula
   desc "Open source continuous profiling software"
   homepage "https://grafana.com/oss/pyroscope/"
-  version "1.12.2"
+  version "1.13.2"
   license "AGPL-3.0-only"
 
   def pyroscope_conf
@@ -15,16 +15,16 @@ class Pyroscope < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/grafana/pyroscope/releases/download/v1.12.2/pyroscope_1.12.2_darwin_amd64.tar.gz"
-      sha256 "52a8e2c0fa739abc896883f04ccd56fac45e5ac2e6b7ef29787ad56490e4ef09"
+      url "https://github.com/grafana/pyroscope/releases/download/v1.13.2/pyroscope_1.13.2_darwin_amd64.tar.gz"
+      sha256 "15ba8f8816ef7b1156c20c277bf5c8447c2bd6ec978a9a2fd1f707dd9efaaac9"
 
       def install
         bin.install "pyroscope"
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/grafana/pyroscope/releases/download/v1.12.2/pyroscope_1.12.2_darwin_arm64.tar.gz"
-      sha256 "17971786b090c9f4ab335cc47bbf32c9c4efc196d2f3cff5aebaf0357d2ab5bf"
+      url "https://github.com/grafana/pyroscope/releases/download/v1.13.2/pyroscope_1.13.2_darwin_arm64.tar.gz"
+      sha256 "60a907f1d5988481c532a428145da8fdf77c56f1be32c94297c58308f30e0537"
 
       def install
         bin.install "pyroscope"
@@ -34,8 +34,8 @@ class Pyroscope < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/grafana/pyroscope/releases/download/v1.12.2/pyroscope_1.12.2_linux_amd64.tar.gz"
-      sha256 "ea93783ebba8f111a1c5779b5443bad9b072c975401cec6621c86d83feb1aa43"
+      url "https://github.com/grafana/pyroscope/releases/download/v1.13.2/pyroscope_1.13.2_linux_amd64.tar.gz"
+      sha256 "6c1cfa0ebff97943d4e1d870162079359852e6d8a6084658968c8e7ec5ed1189"
 
       def install
         bin.install "pyroscope"
@@ -43,8 +43,8 @@ class Pyroscope < Formula
     end
     if Hardware::CPU.arm?
       if Hardware::CPU.is_64_bit?
-        url "https://github.com/grafana/pyroscope/releases/download/v1.12.2/pyroscope_1.12.2_linux_arm64.tar.gz"
-        sha256 "cfe6cf0ef4b12414f0e2514227b531e25243fdfda273dc1a59dfb6e2bc38f5ba"
+        url "https://github.com/grafana/pyroscope/releases/download/v1.13.2/pyroscope_1.13.2_linux_arm64.tar.gz"
+        sha256 "4ba5ba5fd5aaab24465e47f3beadab578a784db94b429e6ba96f06441bc90c2d"
 
         def install
           bin.install "pyroscope"

--- a/Formula/pyroscope.rb.tpl
+++ b/Formula/pyroscope.rb.tpl
@@ -41,16 +41,13 @@ class Pyroscope < Formula
         bin.install "pyroscope"
       end
     end
-    if Hardware::CPU.arm?
-      if Hardware::CPU.is_64_bit?
-        url "https://github.com/grafana/pyroscope/releases/download/{{.Tag}}/pyroscope_{{.Version}}_linux_arm64.tar.gz"
-        sha256 "{{.LinuxArm64}}"
+    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+      url "https://github.com/grafana/pyroscope/releases/download/{{.Tag}}/pyroscope_{{.Version}}_linux_arm64.tar.gz"
+      sha256 "{{.LinuxArm64}}"
 
-        def install
-          bin.install "pyroscope"
-        end
+      def install
+        bin.install "pyroscope"
       end
-      # Removed armv7 section as it's deprecated
     end
   end
 


### PR DESCRIPTION
This reverts commit 810372ddfba4e9a121f96d09591a96928295be6a.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts version and URL updates in `profilecli.rb` and `pyroscope.rb` from `1.13.2` to `1.12.2`.
> 
>   - **Revert Changes**:
>     - Reverts version update from `1.13.2` to `1.12.2` in `profilecli.rb` and `pyroscope.rb`.
>     - Reverts download URLs and SHA256 checksums for both `profilecli` and `pyroscope` for macOS and Linux, affecting both Intel and ARM architectures.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=pyroscope-io%2Fhomebrew-brew&utm_source=github&utm_medium=referral)<sup> for bdb77009a74674f0fb3776d1ab549d284493beb5. You can [customize](https://app.ellipsis.dev/pyroscope-io/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->