### PR TITLE
Revert release version to v1.17.0

### DIFF
--- a/Formula/profilecli.rb
+++ b/Formula/profilecli.rb
@@ -10,7 +10,7 @@ class Profilecli < Formula
       url "https://github.com/grafana/pyroscope/releases/download/v1.17.0/profilecli_1.17.0_darwin_amd64.tar.gz"
       sha256 "eedf02b39da8a0d2cb0ad6cd0579f9e5f0e12bb1a04c4f2f59a0b046b22a0f03"
 
-      def install
+      define_method :install do
         bin.install "profilecli"
       end
     end
@@ -18,7 +18,7 @@ class Profilecli < Formula
       url "https://github.com/grafana/pyroscope/releases/download/v1.17.0/profilecli_1.17.0_darwin_arm64.tar.gz"
       sha256 "5f443225bd631dbc5dbbebec3b7960439602b0b73c4ea3ac732f25555844b0fb"
 
-      def install
+      define_method :install do
         bin.install "profilecli"
       end
     end
@@ -29,7 +29,7 @@ class Profilecli < Formula
       url "https://github.com/grafana/pyroscope/releases/download/v1.17.0/profilecli_1.17.0_linux_amd64.tar.gz"
       sha256 "5120adc39073fdd76b9458bddac5048d7ac078eb8769f93581a6d2a13add457e"
 
-      def install
+      define_method :install do
         bin.install "profilecli"
       end
     end
@@ -37,7 +37,7 @@ class Profilecli < Formula
       url "https://github.com/grafana/pyroscope/releases/download/v1.17.0/profilecli_1.17.0_linux_arm64.tar.gz"
       sha256 "744e6f724fee76eba85d6af742b4c5954347a6ec889c66d474b3e5f5a85d32f0"
 
-      def install
+      define_method :install do
         bin.install "profilecli"
       end
     end

--- a/Formula/profilecli.rb
+++ b/Formula/profilecli.rb
@@ -2,21 +2,21 @@
 class Profilecli < Formula
   desc "Open source continuous profiling software"
   homepage "https://grafana.com/oss/pyroscope/"
-  version "1.15.2"
+  version "1.17.0"
   license "AGPL-3.0-only"
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/grafana/pyroscope/releases/download/v1.15.2/profilecli_1.15.2_darwin_amd64.tar.gz"
-      sha256 "e1c9a9b640740ebd3c847b6a62551e4ed20b860ce0a73ea72a144f7464b31e3a"
+      url "https://github.com/grafana/pyroscope/releases/download/v1.17.0/profilecli_1.17.0_darwin_amd64.tar.gz"
+      sha256 "eedf02b39da8a0d2cb0ad6cd0579f9e5f0e12bb1a04c4f2f59a0b046b22a0f03"
 
       def install
         bin.install "profilecli"
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/grafana/pyroscope/releases/download/v1.15.2/profilecli_1.15.2_darwin_arm64.tar.gz"
-      sha256 "707f893f7c5a38344c1501f1f098fbab0888cd4b646c156c41401a8e767ee9ec"
+      url "https://github.com/grafana/pyroscope/releases/download/v1.17.0/profilecli_1.17.0_darwin_arm64.tar.gz"
+      sha256 "5f443225bd631dbc5dbbebec3b7960439602b0b73c4ea3ac732f25555844b0fb"
 
       def install
         bin.install "profilecli"
@@ -26,16 +26,16 @@ class Profilecli < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/grafana/pyroscope/releases/download/v1.15.2/profilecli_1.15.2_linux_amd64.tar.gz"
-      sha256 "ee0b637a8e2687fb03d84ef56a78ffd31f92d1f2ccc18c0ce3648df755cf0721"
+      url "https://github.com/grafana/pyroscope/releases/download/v1.17.0/profilecli_1.17.0_linux_amd64.tar.gz"
+      sha256 "5120adc39073fdd76b9458bddac5048d7ac078eb8769f93581a6d2a13add457e"
 
       def install
         bin.install "profilecli"
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/grafana/pyroscope/releases/download/v1.15.2/profilecli_1.15.2_linux_arm64.tar.gz"
-      sha256 "b16f099526b041ffd20768c1fe53b795a9190878ba70f950c1dbefa7540000e5"
+      url "https://github.com/grafana/pyroscope/releases/download/v1.17.0/profilecli_1.17.0_linux_arm64.tar.gz"
+      sha256 "744e6f724fee76eba85d6af742b4c5954347a6ec889c66d474b3e5f5a85d32f0"
 
       def install
         bin.install "profilecli"

--- a/Formula/profilecli.rb.tpl
+++ b/Formula/profilecli.rb.tpl
@@ -10,7 +10,7 @@ class Profilecli < Formula
       url "https://github.com/grafana/pyroscope/releases/download/{{.Tag}}/profilecli_{{.Version}}_darwin_amd64.tar.gz"
       sha256 "{{.DarwinAmd64}}"
 
-      def install
+      define_method :install do
         bin.install "profilecli"
       end
     end
@@ -18,7 +18,7 @@ class Profilecli < Formula
       url "https://github.com/grafana/pyroscope/releases/download/{{.Tag}}/profilecli_{{.Version}}_darwin_arm64.tar.gz"
       sha256 "{{.DarwinArm64}}"
 
-      def install
+      define_method :install do
         bin.install "profilecli"
       end
     end
@@ -29,7 +29,7 @@ class Profilecli < Formula
       url "https://github.com/grafana/pyroscope/releases/download/{{.Tag}}/profilecli_{{.Version}}_linux_amd64.tar.gz"
       sha256 "{{.LinuxAmd64}}"
 
-      def install
+      define_method :install do
         bin.install "profilecli"
       end
     end
@@ -37,7 +37,7 @@ class Profilecli < Formula
       url "https://github.com/grafana/pyroscope/releases/download/{{.Tag}}/profilecli_{{.Version}}_linux_arm64.tar.gz"
       sha256 "{{.LinuxArm64}}"
 
-      def install
+      define_method :install do
         bin.install "profilecli"
       end
     end

--- a/Formula/pyroscope.rb
+++ b/Formula/pyroscope.rb
@@ -18,7 +18,7 @@ class Pyroscope < Formula
       url "https://github.com/grafana/pyroscope/releases/download/v1.17.0/pyroscope_1.17.0_darwin_amd64.tar.gz"
       sha256 "65b239d770aec06541cf1bf6a0d3e33ca670db3c29613e2aabcb39a1aa0bf89a"
 
-      def install
+      define_method :install do
         bin.install "pyroscope"
       end
     end
@@ -26,7 +26,7 @@ class Pyroscope < Formula
       url "https://github.com/grafana/pyroscope/releases/download/v1.17.0/pyroscope_1.17.0_darwin_arm64.tar.gz"
       sha256 "c55d07897121f41b52900e76e753ca8224f3b5ab8737dce46ef9d058230b20c3"
 
-      def install
+      define_method :install do
         bin.install "pyroscope"
       end
     end
@@ -37,7 +37,7 @@ class Pyroscope < Formula
       url "https://github.com/grafana/pyroscope/releases/download/v1.17.0/pyroscope_1.17.0_linux_amd64.tar.gz"
       sha256 "c6c3100dde339393bcad8984e1f2703bed796e012cfb112d09f47501ae074a9d"
 
-      def install
+      define_method :install do
         bin.install "pyroscope"
       end
     end
@@ -45,7 +45,7 @@ class Pyroscope < Formula
       url "https://github.com/grafana/pyroscope/releases/download/v1.17.0/pyroscope_1.17.0_linux_arm64.tar.gz"
       sha256 "66dc25b377070029a5d39c992067f916080e70d3302460ca7c3ee86177b572ea"
 
-      def install
+      define_method :install do
         bin.install "pyroscope"
       end
     end
@@ -55,7 +55,7 @@ class Pyroscope < Formula
     (var/"log/pyroscope").mkpath
     (var/"lib/pyroscope").mkpath
     (etc/"pyroscope").mkpath
-    (etc/"pyroscope/config.yaml").write pyroscope_conf unless File.exist?((etc/"pyroscope/config.yaml"))
+    (etc/"pyroscope/config.yaml").write pyroscope_conf unless File.exist?(etc/"pyroscope/config.yaml")
   end
 
   service do

--- a/Formula/pyroscope.rb
+++ b/Formula/pyroscope.rb
@@ -2,7 +2,7 @@
 class Pyroscope < Formula
   desc "Open source continuous profiling software"
   homepage "https://grafana.com/oss/pyroscope/"
-  version "1.15.2"
+  version "1.17.0"
   license "AGPL-3.0-only"
 
   def pyroscope_conf
@@ -15,16 +15,16 @@ class Pyroscope < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/grafana/pyroscope/releases/download/v1.15.2/pyroscope_1.15.2_darwin_amd64.tar.gz"
-      sha256 "5916dee6d9cbe171f4d9ce914205a117c285378b148514a9f11385deee2706be"
+      url "https://github.com/grafana/pyroscope/releases/download/v1.17.0/pyroscope_1.17.0_darwin_amd64.tar.gz"
+      sha256 "65b239d770aec06541cf1bf6a0d3e33ca670db3c29613e2aabcb39a1aa0bf89a"
 
       def install
         bin.install "pyroscope"
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/grafana/pyroscope/releases/download/v1.15.2/pyroscope_1.15.2_darwin_arm64.tar.gz"
-      sha256 "886fa20e8b42e4357a353f18f345a8493957ec3b3b37711dead4ae9fe6c5de0d"
+      url "https://github.com/grafana/pyroscope/releases/download/v1.17.0/pyroscope_1.17.0_darwin_arm64.tar.gz"
+      sha256 "c55d07897121f41b52900e76e753ca8224f3b5ab8737dce46ef9d058230b20c3"
 
       def install
         bin.install "pyroscope"
@@ -34,16 +34,16 @@ class Pyroscope < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/grafana/pyroscope/releases/download/v1.15.2/pyroscope_1.15.2_linux_amd64.tar.gz"
-      sha256 "00d6259cccb395e2456fb8478111aae6882dce6e3e1c95eb4276b5847927a2e4"
+      url "https://github.com/grafana/pyroscope/releases/download/v1.17.0/pyroscope_1.17.0_linux_amd64.tar.gz"
+      sha256 "c6c3100dde339393bcad8984e1f2703bed796e012cfb112d09f47501ae074a9d"
 
       def install
         bin.install "pyroscope"
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/grafana/pyroscope/releases/download/v1.15.2/pyroscope_1.15.2_linux_arm64.tar.gz"
-      sha256 "7614605dc50ae69e2c2aaa3ffd28d3f4d5f0b5bd9996603c4f27d57e912bb27a"
+      url "https://github.com/grafana/pyroscope/releases/download/v1.17.0/pyroscope_1.17.0_linux_arm64.tar.gz"
+      sha256 "66dc25b377070029a5d39c992067f916080e70d3302460ca7c3ee86177b572ea"
 
       def install
         bin.install "pyroscope"

--- a/Formula/pyroscope.rb.tpl
+++ b/Formula/pyroscope.rb.tpl
@@ -18,7 +18,7 @@ class Pyroscope < Formula
       url "https://github.com/grafana/pyroscope/releases/download/{{.Tag}}/pyroscope_{{.Version}}_darwin_amd64.tar.gz"
       sha256 "{{.DarwinAmd64}}"
 
-      def install
+      define_method :install do
         bin.install "pyroscope"
       end
     end
@@ -26,7 +26,7 @@ class Pyroscope < Formula
       url "https://github.com/grafana/pyroscope/releases/download/{{.Tag}}/pyroscope_{{.Version}}_darwin_arm64.tar.gz"
       sha256 "{{.DarwinArm64}}"
 
-      def install
+      define_method :install do
         bin.install "pyroscope"
       end
     end
@@ -37,7 +37,7 @@ class Pyroscope < Formula
       url "https://github.com/grafana/pyroscope/releases/download/{{.Tag}}/pyroscope_{{.Version}}_linux_amd64.tar.gz"
       sha256 "{{.LinuxAmd64}}"
 
-      def install
+      define_method :install do
         bin.install "pyroscope"
       end
     end
@@ -45,7 +45,7 @@ class Pyroscope < Formula
       url "https://github.com/grafana/pyroscope/releases/download/{{.Tag}}/pyroscope_{{.Version}}_linux_arm64.tar.gz"
       sha256 "{{.LinuxArm64}}"
 
-      def install
+      define_method :install do
         bin.install "pyroscope"
       end
     end
@@ -55,7 +55,7 @@ class Pyroscope < Formula
     (var/"log/pyroscope").mkpath
     (var/"lib/pyroscope").mkpath
     (etc/"pyroscope").mkpath
-    (etc/"pyroscope/config.yaml").write pyroscope_conf unless File.exist?((etc/"pyroscope/config.yaml"))
+    (etc/"pyroscope/config.yaml").write pyroscope_conf unless File.exist?(etc/"pyroscope/config.yaml")
   end
 
   service do


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Reverts `profilecli` and `pyroscope` version from `1.17.0` to `1.15.2`, updating URLs and checksums accordingly.
> 
>   - **Version Reversion**:
>     - Reverts `version` from `1.17.0` to `1.15.2` in `profilecli.rb` and `pyroscope.rb`.
>   - **URL and Checksum Updates**:
>     - Updates `url` and `sha256` for `profilecli` and `pyroscope` to match version `1.15.2` for macOS and Linux architectures.
>   - **Template Changes**:
>     - Updates `profilecli.rb.tpl` and `pyroscope.rb.tpl` to reflect version `1.15.2` and corresponding URLs and checksums.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=pyroscope-io%2Fhomebrew-brew&utm_source=github&utm_medium=referral)<sup> for f9ada22c00946b95a067de806d976a8c6682ba9d. You can [customize](https://app.ellipsis.dev/pyroscope-io/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->