### PR TITLE
chore: update formulas to v2.0.3

### DIFF
--- a/Formula/profilecli.rb
+++ b/Formula/profilecli.rb
@@ -2,21 +2,21 @@
 class Profilecli < Formula
   desc "Open source continuous profiling software"
   homepage "https://grafana.com/oss/pyroscope/"
-  version "2.0.2"
+  version "2.0.3"
   license "AGPL-3.0-only"
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/grafana/pyroscope/releases/download/v2.0.2/profilecli_2.0.2_darwin_amd64.tar.gz"
-      sha256 "f1860ffc750705878c7419bd49df1db41bff407468ce3f8d2ccde98fab27b3b0"
+      url "https://github.com/grafana/pyroscope/releases/download/v2.0.3/profilecli_2.0.3_darwin_amd64.tar.gz"
+      sha256 "cc21d4189b6220d3d44b5e8d4e96523ed431929e8accf49a914b77a1026f8027"
 
       define_method :install do
         bin.install "profilecli"
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/grafana/pyroscope/releases/download/v2.0.2/profilecli_2.0.2_darwin_arm64.tar.gz"
-      sha256 "115964768b8199dc7b1fb79e696d3a6e36df66d6ff996ade05c2bad16d316bc8"
+      url "https://github.com/grafana/pyroscope/releases/download/v2.0.3/profilecli_2.0.3_darwin_arm64.tar.gz"
+      sha256 "f3f1c5af9b4a45bffeb5e04fd9580a5745132cd7c4897a17e244c80ddd645cce"
 
       define_method :install do
         bin.install "profilecli"
@@ -26,16 +26,16 @@ class Profilecli < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/grafana/pyroscope/releases/download/v2.0.2/profilecli_2.0.2_linux_amd64.tar.gz"
-      sha256 "327f320f9fb0fae27d23611f7f8951f306b98d5ce831ec9eada99025d22fb7c1"
+      url "https://github.com/grafana/pyroscope/releases/download/v2.0.3/profilecli_2.0.3_linux_amd64.tar.gz"
+      sha256 "9bf8cb0e73bc9e2db73302455f313f5dc2bcb9396fb71744d2ad9365fa0e015d"
 
       define_method :install do
         bin.install "profilecli"
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/grafana/pyroscope/releases/download/v2.0.2/profilecli_2.0.2_linux_arm64.tar.gz"
-      sha256 "28edb6d57702f45dd89c70dc405c24e23fc81b093807f889a52c1e8333cdbf5d"
+      url "https://github.com/grafana/pyroscope/releases/download/v2.0.3/profilecli_2.0.3_linux_arm64.tar.gz"
+      sha256 "c7b843a9bfff7dac81223e97fd32325749ae61c237a0019ab69fd7a75423d88b"
 
       define_method :install do
         bin.install "profilecli"

--- a/Formula/pyroscope.rb
+++ b/Formula/pyroscope.rb
@@ -2,7 +2,7 @@
 class Pyroscope < Formula
   desc "Open source continuous profiling software"
   homepage "https://grafana.com/oss/pyroscope/"
-  version "2.0.2"
+  version "2.0.3"
   license "AGPL-3.0-only"
 
   def pyroscope_conf
@@ -15,16 +15,16 @@ class Pyroscope < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/grafana/pyroscope/releases/download/v2.0.2/pyroscope_2.0.2_darwin_amd64.tar.gz"
-      sha256 "610b45e5ad45297c54ccfe3b5766b0882ae5ada3f90256df3915aafd2e88d815"
+      url "https://github.com/grafana/pyroscope/releases/download/v2.0.3/pyroscope_2.0.3_darwin_amd64.tar.gz"
+      sha256 "f1fc2b2152f03407ec09eb1bd4ea2ed1f8036d6662a94f8235fff321763fb5bc"
 
       define_method :install do
         bin.install "pyroscope"
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/grafana/pyroscope/releases/download/v2.0.2/pyroscope_2.0.2_darwin_arm64.tar.gz"
-      sha256 "a8ebd0c3b9a5abe2d21c2bc2ad2076b5ea2b8adec09b69c09b450330816f8def"
+      url "https://github.com/grafana/pyroscope/releases/download/v2.0.3/pyroscope_2.0.3_darwin_arm64.tar.gz"
+      sha256 "972adceefd8906641fcac4fa687bce9b2f895c9d4917ff38b2340981feaed076"
 
       define_method :install do
         bin.install "pyroscope"
@@ -34,16 +34,16 @@ class Pyroscope < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/grafana/pyroscope/releases/download/v2.0.2/pyroscope_2.0.2_linux_amd64.tar.gz"
-      sha256 "d4ed2d1f24532222436a1512ba033386154377e19bf371f49070755e7e4fe250"
+      url "https://github.com/grafana/pyroscope/releases/download/v2.0.3/pyroscope_2.0.3_linux_amd64.tar.gz"
+      sha256 "8a81c082f8cb207342cf74a10f79643bdbe04da942aa7fc26fc5bd22a1a32ed6"
 
       define_method :install do
         bin.install "pyroscope"
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/grafana/pyroscope/releases/download/v2.0.2/pyroscope_2.0.2_linux_arm64.tar.gz"
-      sha256 "f8fbc65bd77b583de3bf84a0bacab4c438598c51a36945388d22510e53b669a6"
+      url "https://github.com/grafana/pyroscope/releases/download/v2.0.3/pyroscope_2.0.3_linux_arm64.tar.gz"
+      sha256 "c6bb1106dcce60bde6ac1f45c31b78f9e9f694fa9ff6d79805da3bc31287c5f5"
 
       define_method :install do
         bin.install "pyroscope"


### PR DESCRIPTION
Updates the `pyroscope` and `profilecli` formulas to **v2.0.3**.

The automated `Update homebrew formulas` step in the pyroscope release workflow (run [26893483450](https://github.com/grafana/pyroscope/actions/runs/26893483450/job/79390975828)) could not push directly to `main`; it's blocked by the org-level "Public repo required PRs" ruleset.

Generated with `PYROSCOPE_TAG=v2.0.3 make generate-formulas` (URLs + sha256 taken from the v2.0.3 release `checksums.txt`).