### PR TITLE
ci: trust tap formulae for brew doctor (least-privilege)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,13 @@ jobs:
 
       - run: brew test-bot --only-cleanup-before
 
+      # Explicitly trust only this tap's own formulae so `brew doctor`
+      # (run by `--only-setup`) passes once Homebrew enforces tap trust.
+      # Least-privilege: scoped to the two formulae in this repo, on the
+      # ephemeral CI runner only. We deliberately avoid
+      # HOMEBREW_NO_REQUIRE_TAP_TRUST, which disables the trust control.
+      - run: brew trust --formula grafana/pyroscope/pyroscope grafana/pyroscope/profilecli
+
       - run: brew test-bot --only-setup
 
       - run: brew test-bot --only-tap-syntax


### PR DESCRIPTION
## Problem
`test-bot` CI fails at `brew test-bot --only-setup` → `brew doctor`:
```
The following taps are not trusted:
  grafana/pyroscope
```
Homebrew is rolling out a supply-chain "tap trust" control; `brew doctor` now treats this tap as untrusted and exits non-zero. It fails before any formula is tested, so it blocks CI for every PR (e.g. the v2.0.3 formula update PR #26).

## Fix
Add one step that explicitly trusts **only this tap's own two formulae**, before `--only-setup`:
```yaml
- run: brew trust --formula grafana/pyroscope/pyroscope grafana/pyroscope/profilecli
```